### PR TITLE
Remove: 去掉"/(api)/delete"中多余的操作

### DIFF
--- a/work4/biz/dal/db/comment.go
+++ b/work4/biz/dal/db/comment.go
@@ -51,7 +51,7 @@ func GetCommentInfo(commentId string) (*Comment, error) {
 
 func GetParentCommentId(commentId string) (string, error) {
 	var parentId string
-	if err := DB.Table(`comments`).Where(`id = ?`, commentId).Select(`parent_id`).Find(parentId).Error; err != nil {
+	if err := DB.Table(`comments`).Where(`id = ?`, commentId).Select(`parent_id`).Find(&parentId).Error; err != nil {
 		return ``, err
 	}
 	return parentId, nil
@@ -59,7 +59,7 @@ func GetParentCommentId(commentId string) (string, error) {
 
 func GetCommentVideoId(commentId string) (string, error) {
 	var videoId string
-	if err := DB.Table(`comments`).Where(`id = ?`, commentId).Select(`video_id`).Find(videoId).Error; err != nil {
+	if err := DB.Table(`comments`).Where(`id = ?`, commentId).Select(`video_id`).Find(&videoId).Error; err != nil {
 		return ``, err
 	}
 	return videoId, nil
@@ -103,48 +103,6 @@ func GetCommentIdList() (*[]string, error) {
 		return nil, err
 	}
 	return &list, nil
-}
-
-func DeleteCommentAndCommentLikeAboutVideo(vid string) error {
-	list, err := GetVideoCommentList(vid)
-	if err != nil {
-		return err
-	}
-	for _, item := range *list {
-		if err := DeleteCommentLikeAboutComment(item); err != nil {
-			return err
-		}
-	}
-	if err := DB.Where(`video_id = ?`, vid).Delete(&Comment{}).Error; err != nil {
-		return err
-	}
-	return nil
-}
-
-func DeleteChildComment(cid string) error {
-	if err := DB.Where("parent_id = ?", cid).Delete(&Comment{}).Error; err != nil {
-		return err
-	}
-	return nil
-}
-
-func DeleteChildAndLikesOfParentAndChild(cid string) error {
-	list, err := GetCommentChildList(cid)
-	if err != nil {
-		return err
-	}
-	if err := DeleteChildComment(cid); err != nil {
-		return err
-	}
-	if err := DeleteCommentLikeAboutComment(cid); err != nil {
-		return err
-	}
-	for _, item := range *list {
-		if err := DeleteCommentLikeAboutComment(item); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func IsCommentExist(cid string) (bool, error) {

--- a/work4/biz/dal/db/comment_likes.go
+++ b/work4/biz/dal/db/comment_likes.go
@@ -43,10 +43,3 @@ func DeleteCommentLike(cid, uid string) error {
 	}
 	return nil
 }
-
-func DeleteCommentLikeAboutComment(cid string) error {
-	if err := DB.Where(`comment_id = ?`, cid).Delete(&CommentLike{}).Error; err != nil {
-		return err
-	}
-	return nil
-}

--- a/work4/biz/dal/db/video_likes.go
+++ b/work4/biz/dal/db/video_likes.go
@@ -1,11 +1,5 @@
 package db
 
-import (
-	"time"
-
-	"gorm.io/gorm/clause"
-)
-
 type VideoLike struct {
 	Id        int64  `json:"id"`
 	UserId    string `json:"user_id"`
@@ -36,21 +30,6 @@ func DeleteVideoLike(vid, uid string) error {
 	return nil
 }
 
-func CreateIfNotExistsVideoLike(vid string, uid string) error {
-	err := DB.Clauses(clause.OnConflict{
-		Columns: []clause.Column{{Name: "video_id"}, {Name: "user_id"}},
-	}).Create(&VideoLike{
-		UserId:    uid,
-		VideoId:   vid,
-		CreatedAt: time.Now().Unix(),
-		DeletedAt: 0,
-	}).Error
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 func GetVideoLikeListByUserId(uid string, pageNum, pageSize int64) (*[]string, error) {
 	list := make([]string, 0)
 	err := DB.Table(`video_likes`).Where(`user_id = ?`, uid).Select("video_id").Limit(int(pageSize)).Offset((int(pageNum-1) * int(pageSize))).Scan(&list).Error
@@ -58,11 +37,4 @@ func GetVideoLikeListByUserId(uid string, pageNum, pageSize int64) (*[]string, e
 		return nil, err
 	}
 	return &list, err
-}
-
-func DeleteLikeAboutVideo(vid string) error {
-	if err := DB.Where(`video_id = ?`, vid).Delete(&VideoLike{}).Error; err != nil {
-		return err
-	}
-	return nil
 }

--- a/work4/biz/service/service_interact.go
+++ b/work4/biz/service/service_interact.go
@@ -272,15 +272,9 @@ func deleteVideo(request *interact.CommentDeleteRequest) error {
 		wg      sync.WaitGroup
 		errChan = make(chan error, 2)
 	)
-	wg.Add(4)
+	wg.Add(3)
 	go func() {
 		if err := db.DeleteVideo(request.VideoId); err != nil {
-			errChan <- errmsg.ServiceError
-		}
-		wg.Done()
-	}()
-	go func() {
-		if err := db.DeleteCommentAndCommentLikeAboutVideo(request.VideoId); err != nil {
 			errChan <- errmsg.ServiceError
 		}
 		wg.Done()
@@ -316,7 +310,7 @@ func deleteComment(request *interact.CommentDeleteRequest) error {
 	)
 	wg.Add(2)
 	go func() {
-		if err := db.DeleteChildAndLikesOfParentAndChild(request.CommentId); err != nil {
+		if err := db.DeleteComment(request.CommentId); err != nil {
 			errChan <- errmsg.RedisError
 		}
 		wg.Done()


### PR DESCRIPTION
由于MySQL的表内添加了级联删除，故不需要像之前那样 "获取依赖数据" -> "连锁删除"